### PR TITLE
add context hooks, add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ development of your application. Other examples of plugins would be CSS compiler
 set to `less`, the construx middleware will attempt to find a file named `<files source path>/foo.less`
 * `precompile` (optional) is a function that can run prior to the construx middleware execution for this plugin. Its signature is 
  `(context, callback)`. Please see description of compile `context` below.
-* `postcompile` (optional) is a function that will run post construx middleware execution for this plugin. Its signature is `(context, callback)`.
+* `postcompile` (optional) is a function that will run post construx middleware execution for this plugin. Its signature is `(context, callback)`. 
+A possible use case for `postcompile` would be if the plugin creates any temporary files/directories during compilation that should be deleted.
 
 #### Middleware process a matched request
 

--- a/README.md
+++ b/README.md
@@ -100,15 +100,20 @@ development of your application. Other examples of plugins would be CSS compiler
     "<plugin key>": {
         "module": "<plugin module name>",
         "files": "<filter on request path>",
-        "ext": "<file extension>"
+        "ext": "<file extension>",
+        "precompile": <Function>,
+        "postcompile": <Function>
     }
 }
 ```
 * `<plugin key>` just needs to be a unique string within the other registered plugins.
 * `module` is the npm package name of your plugin.
 * `files` is a glob string which will try and match the `req.path`. If there is a match, the plugin middleware will be engaged
-* `ext` is a replacement for the requested file's extension. E.g. if a `GET` request comes across for `/css/foo.css`, and `ext` is 
+* `ext` (optional) is a replacement for the requested file's extension. E.g. if a `GET` request comes across for `/css/foo.css`, and `ext` is 
 set to `less`, the construx middleware will attempt to find a file named `<files source path>/foo.less`
+* `precompile` (optional) is a function that can run prior to the construx middleware execution for this plugin. Its signature is 
+ `(context, callback)`. Please see description of compile `context` below.
+* `postcompile` (optional) is a function that will run post construx middleware execution for this plugin. Its signature is `(context, callback)`.
 
 #### Middleware process a matched request
 
@@ -143,13 +148,19 @@ context = {
 };
 ```
 
-You might use the context to pass stateful information from a preHook to your plugin (see elsewhere), or to flag construx middleware 
-about special conditions
+_Note: There are a couple possible overrides to the context object which you might want to take advantage of. See below._
 
 * `<options>` is the JSON object used to register the plugin (see #Plugin-registration above).
 
 The plugin's compiler will do whatever transformation to the raw buffer, and issue a `callback` to the construx middleware 
 with the transformed file (or an error).
+
+#### context overrides
+
+`srcPath`: If you want to compute the source file differently than the construx middleware, you can add `srcPath` to the 
+context object (in a `precompile` step usually) and the construx middleware will use your value instead of its own logic
+`skipRead`: If you don't want the construx middleware to open the source file (because for example, your compiler does that instead) 
+then set the `skipRead` flag to be true
 
 ### Author a plugin
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -120,6 +120,10 @@ function createExecutor(compiler, options) {
 function exec(compiler, context, options, callback) {
 
     var reqFile, destFile, srcPath, destPath;
+    var noReadOp = function (src, cb) {
+        cb(null, ' ');
+    };
+    var readOp = (context.skipRead) ? noReadOp : fs.readFile;
 
     reqFile = destFile = context.filePath;
 
@@ -138,7 +142,8 @@ function exec(compiler, context, options, callback) {
     }
     destPath = path.join(context.destRoot, destFile);
 
-    fs.readFile(srcPath, function (err, raw) {
+
+    readOp(srcPath, function (err, raw) {
         var dirs, dir;
 
         if (err) {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -24,7 +24,7 @@ var fs = require('fs'),
   mkdirp = require('mkdirp'),
   merge = require('n-deep-merge'),
   noop = require('./noop'),
-  debuglog = require('debuglog')('kraken-devtools'),
+  debuglog = require('debuglog')('construx'),
   filter = require('./filter');
 
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -19,13 +19,13 @@
 
 
 var fs = require('fs'),
-    path = require('path'),
-	async = require('async'),
-    mkdirp = require('mkdirp'),
-    merge = require('n-deep-merge'),
-	noop = require('./noop'),
-	debuglog = require('debuglog')('construx'),
-	filter = require('./filter');
+  path = require('path'),
+  async = require('async'),
+  mkdirp = require('mkdirp'),
+  merge = require('n-deep-merge'),
+  noop = require('./noop'),
+  debuglog = require('debuglog')('kraken-devtools'),
+  filter = require('./filter');
 
 
 module.exports = function middleware(srcRoot, destRoot, options, compiler) {
@@ -57,14 +57,14 @@ module.exports = function middleware(srcRoot, destRoot, options, compiler) {
             }
 
             // get the filename
-            regex = new RegExp(dir + '/(.*)' + ext +'$', 'i');
+            regex = new RegExp(dir + '/(.*)' + ext + '$', 'i');
             name = regex.exec(filePath)[1];
 
             filePath = filePath.replace('/', path.sep);
 
             // The compile context is passed through all compile steps
             context = {
-                srcRoot:  srcRoot,
+                srcRoot: srcRoot,
                 destRoot: destRoot,
                 filePath: filePath,
                 name: name,
@@ -78,14 +78,12 @@ module.exports = function middleware(srcRoot, destRoot, options, compiler) {
 
         async.waterfall([start].concat(tasks), function (err) {
             // Guard against modules throwing whatever they damn well please.
-
             if (typeof err === 'string') {
                 err = new Error(err);
             }
 
-            //// TODO: push this responsibility to the less plugin(s)
-            //// On Ubuntu, `less` failures return an object that is not an error but has the structure
-            //// { type: '', message: '', index: '' } so we need to accommodate that. :/
+            // On Ubuntu, `less` failures return an object that is not an error but has the structure
+            // { type: '', message: '', index: '' } so we need to accommodate that. :/
             if (typeof err === 'object' && err !== null && !(err instanceof Error)) {
                 err = Object.keys(err).reduce(function (dest, prop) {
                     dest[prop] = err[prop];
@@ -121,17 +119,17 @@ function createExecutor(compiler, options) {
 
 function exec(compiler, context, options, callback) {
 
-    var srcFile, destFile, srcPath, destPath;
+    var srcFile, reqFile, destFile, srcPath, destPath;
 
-    srcFile = destFile = context.filePath;
+    reqFile = destFile = context.filePath;
 
     if (context.ext) {
         // XXX: compiler.name is source file extension, so if there's no name we don't concern ourselves
         // with looking for a source file that's different from the dest file.
-        srcFile = srcFile.replace(path.extname(srcFile), '') + '.' + context.ext;
+        reqFile = reqFile.replace(path.extname(reqFile), '') + '.' + context.ext;
     }
 
-    srcPath  = path.join(context.srcRoot, srcFile);
+    srcPath = (context.srcPath) ? context.srcPath : path.join(context.srcRoot, reqFile);
     destPath = path.join(context.destRoot, destFile);
 
     fs.readFile(srcPath, function (err, raw) {
@@ -150,7 +148,7 @@ function exec(compiler, context, options, callback) {
             dir = path.dirname(dir);
         }
 
-        var config = merge({ paths: dirs, context: context }, options);
+        var config = merge({paths: dirs, context: context}, options);
 
         compiler(raw, config, function (err, result) {
             if (err) {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -119,17 +119,23 @@ function createExecutor(compiler, options) {
 
 function exec(compiler, context, options, callback) {
 
-    var srcFile, reqFile, destFile, srcPath, destPath;
+    var reqFile, destFile, srcPath, destPath;
 
     reqFile = destFile = context.filePath;
 
-    if (context.ext) {
-        // XXX: compiler.name is source file extension, so if there's no name we don't concern ourselves
-        // with looking for a source file that's different from the dest file.
-        reqFile = reqFile.replace(path.extname(reqFile), '') + '.' + context.ext;
+    if (context.srcPath) {
+        //context.srcPath was set by a preHook
+        srcPath = context.srcPath;
     }
-
-    srcPath = (context.srcPath) ? context.srcPath : path.join(context.srcRoot, reqFile);
+    else if (context.ext) {
+        //context.srcPath is just reqFile with a different extension
+        srcPath = reqFile.replace(path.extname(reqFile), '') + '.' + context.ext;
+        srcPath = path.join(context.srcRoot, srcPath);
+    }
+    else {
+        //reqFile name maps directly to srcPath name
+        srcPath = path.join(context.srcRoot, reqFile);
+    }
     destPath = path.join(context.destRoot, destFile);
 
     fs.readFile(srcPath, function (err, raw) {


### PR DESCRIPTION
- added `srcPath` context override in order that a plugin can supersede the built-in srcPath calculation
- added `skipRead` context override in order that a plugin can prevent its middleware from opening a file (this is currently useful for supporting the older dustjs-i18n use case, where the plugin passes the file path on to `localizr` and the middleware-read file buffer is never used)
- added detailed documentation on plugin registration, middleware execution, and these new overrides
